### PR TITLE
Update VerificationController.stub verify method

### DIFF
--- a/stubs/Controllers/Auth/VerificationController.stub
+++ b/stubs/Controllers/Auth/VerificationController.stub
@@ -3,6 +3,7 @@
 namespace {{namespace}}\Http\Controllers\{{singularClass}}\Auth;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 use Illuminate\Foundation\Auth\VerifiesEmails;
 
@@ -63,6 +64,8 @@ class VerificationController extends Controller
     {
         if ($request->route('id') == $request->user('{{singularSlug}}')->getKey()) {
             $request->user('{{singularSlug}}')->markEmailAsVerified();
+        } else {
+            abort(Response::HTTP_FORBIDDEN);
         }
 
         return redirect($this->redirectPath());


### PR DESCRIPTION
Call to `verify` should, instead of redirecting to "after verification", abort with HTTP 403 when the route id doesn't match the authenticated user's id. HTH :)